### PR TITLE
fix: 🩹 ライセンスファイルを修正

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -631,8 +631,8 @@ to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) <year>  <name of author>
+    Template for building AWS resources with 3-tier web configuration.
+    Copyright (C) 2024 Yusuke TOMIOKA <vlayusuke@gmail.com>
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -652,7 +652,7 @@ Also add information on how to contact you by electronic and paper mail.
   If the program does terminal interaction, make it output a short
 notice like this when it starts in an interactive mode:
 
-    <program>  Copyright (C) <year>  <name of author>
+    vlayusuke-terraform-infrastructure  Copyright (C) 2024 Yusuke TOMIOKA <vlayusuke@gmail.com>
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.


### PR DESCRIPTION
GNU 3.0に基づき、テンプレートファイルからライセンスの所有者を修正。